### PR TITLE
Feature/update popovers

### DIFF
--- a/Blazor.DriverJs.Web/Pages/Index.razor
+++ b/Blazor.DriverJs.Web/Pages/Index.razor
@@ -32,6 +32,10 @@
 
 <DriverStore OnNextStep="NextStepHandler"></DriverStore>
 
+<button @onclick="ClickHandler2" id="helloworld">
+    World Hello
+</button>
+
 @code {
 
     private DriverStore _store;
@@ -45,6 +49,14 @@
         await DriverJs.Highlight(new HighlightModel(_ref)
         {
             Title = "Hello World",
+        });
+    }
+
+    private async Task ClickHandler2()
+    {
+        await DriverJs.Highlight(new HighlightModel("helloworld")
+        {
+            Title = "World Hello"
         });
     }
 

--- a/Blazor.DriverJs.Web/Pages/Index.razor
+++ b/Blazor.DriverJs.Web/Pages/Index.razor
@@ -18,6 +18,11 @@
         <DriverJsPopover Step="3" Title="And that's a cool smiley face">
             <img src="https://i.pinimg.com/736x/40/bb/da/40bbdac7db3945f95eb9cfe572d36ecd.jpg" alt="">
         </DriverJsPopover>
+
+        <DriverJsPopoverId Step="4" Title="Hello World">
+            <img src="https://i.pinimg.com/736x/40/bb/da/40bbdac7db3945f95eb9cfe572d36ecd.jpg" alt=""
+                 id="@context">
+        </DriverJsPopoverId>
     </DriverStore>
 </div>
 
@@ -47,5 +52,5 @@
     {
         var currentPopover = _store.Popovers[index];
     }
-    
+
 }

--- a/Blazor.DriverJs/DriverJsPopover.razor
+++ b/Blazor.DriverJs/DriverJsPopover.razor
@@ -1,1 +1,3 @@
-﻿<span @ref="_ref" class="@Class">@ChildContent</span>
+﻿@inherits DriverJsPopoverProps
+
+<span @ref="Ref" class="@Class">@ChildContent</span>

--- a/Blazor.DriverJs/DriverJsPopover.razor
+++ b/Blazor.DriverJs/DriverJsPopover.razor
@@ -1,3 +1,67 @@
 ﻿@inherits DriverJsPopoverProps
+@implements IAsyncDisposable
 
 <span @ref="Ref" class="@Class">@ChildContent</span>
+
+@code {
+
+    private ElementReference Ref
+    {
+        set
+        {
+            Model.Element = value;
+            Store.AddPopover(Step, Model);
+        }
+    }
+
+    #region Props
+
+    [Parameter] public RenderFragment? ChildContent { get; set; }
+
+    [Parameter, EditorRequired] public int Step { get; set; }
+    
+    #endregion
+    
+    [CascadingParameter] public DriverStore Store { get; set; }
+
+    protected override void OnInitialized()
+    {
+        OnDisableButtonUpdate += UpdateDisableButtons;
+        OnShowButtonUpdate += UpdateShowButtons;
+        
+        base.OnInitialized();
+    }
+
+    private void UpdateShowButtons(object? sender, EventArgs args)
+    {
+        var buttons = new List<string>();
+
+        if (ShowNextButton) buttons.Add(DriverJsDefaultValues.ButtonNext);
+        if (ShowCloseButton) buttons.Add(DriverJsDefaultValues.ButtonClose);
+        if (ShowPreviousButton) buttons.Add(DriverJsDefaultValues.ButtonPrevious);
+
+        Model.ShowButtons = buttons.Count > 0 ? buttons.ToArray() : null;
+    }
+
+    private void UpdateDisableButtons(object? sender, EventArgs args)
+    {
+        var buttons = new List<string>();
+
+        if (DisableCloseButton) buttons.Add(DriverJsDefaultValues.ButtonClose);
+        if (DisableNextButton) buttons.Add(DriverJsDefaultValues.ButtonNext);
+        if (DisablePreviousButton) buttons.Add(DriverJsDefaultValues.ButtonPrevious);
+
+        Model.DisableButtons = buttons.Count > 0 ? buttons.ToArray() : null;
+    }
+
+    public ValueTask DisposeAsync()
+    {
+        OnDisableButtonUpdate -= UpdateDisableButtons;
+        OnShowButtonUpdate -= UpdateShowButtons;
+        
+        Store.RemovePopover(Step);
+        
+        return ValueTask.CompletedTask;
+    }
+
+}

--- a/Blazor.DriverJs/DriverJsPopover.razor.cs
+++ b/Blazor.DriverJs/DriverJsPopover.razor.cs
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.Components;
 
 namespace Blazor.DriverJs;
 
-public partial class DriverJsPopover : IDisposable
+public partial class DriverJsPopover : IAsyncDisposable
 {
     private ElementReference Ref
     {
@@ -17,7 +17,14 @@ public partial class DriverJsPopover : IDisposable
 
     [CascadingParameter] public DriverStore Store { get; set; }
 
-    private void UpdateShowButtons()
+    protected override void OnInitialized()
+    {
+        OnDisableButtonUpdate += UpdateDisableButtons;
+        OnShowButtonUpdate += UpdateShowButtons;
+        base.OnInitialized();
+    }
+
+    private void UpdateShowButtons(object? sender, EventArgs args)
     {
         var buttons = new List<string>();
 
@@ -28,7 +35,7 @@ public partial class DriverJsPopover : IDisposable
         Model.ShowButtons = buttons.Count > 0 ? buttons.ToArray() : null;
     }
 
-    private void UpdateDisableButtons()
+    private void UpdateDisableButtons(object? sender, EventArgs args)
     {
         var buttons = new List<string>();
 
@@ -39,8 +46,11 @@ public partial class DriverJsPopover : IDisposable
         Model.DisableButtons = buttons.Count > 0 ? buttons.ToArray() : null;
     }
 
-    public void Dispose()
+    public ValueTask DisposeAsync()
     {
+        OnDisableButtonUpdate -= UpdateDisableButtons;
+        OnShowButtonUpdate -= UpdateShowButtons;
         Store.RemovePopover(Step);
+        return ValueTask.CompletedTask;
     }
 }

--- a/Blazor.DriverJs/DriverJsPopover.razor.cs
+++ b/Blazor.DriverJs/DriverJsPopover.razor.cs
@@ -6,21 +6,21 @@ namespace Blazor.DriverJs;
 
 public partial class DriverJsPopover : IDisposable
 {
-    private ElementReference _ref;
+    private ElementReference Ref
+    {
+        set
+        {
+            Model.Element = value;
+            Store.AddPopover(Step, Model);
+        }
+    }
 
     [CascadingParameter] public DriverStore Store { get; set; }
-
-    protected override void OnAfterRender(bool firstRender)
-    {
-        Model.Element = _ref;
-        if (firstRender) Store.AddPopover(Step, Model);
-        base.OnAfterRender(firstRender);
-    }
 
     private void UpdateShowButtons()
     {
         var buttons = new List<string>();
-        
+
         if (ShowNextButton) buttons.Add(DriverJsDefaultValues.ButtonNext);
         if (ShowCloseButton) buttons.Add(DriverJsDefaultValues.ButtonClose);
         if (ShowPreviousButton) buttons.Add(DriverJsDefaultValues.ButtonPrevious);
@@ -31,7 +31,7 @@ public partial class DriverJsPopover : IDisposable
     private void UpdateDisableButtons()
     {
         var buttons = new List<string>();
-        
+
         if (DisableCloseButton) buttons.Add(DriverJsDefaultValues.ButtonClose);
         if (DisableNextButton) buttons.Add(DriverJsDefaultValues.ButtonNext);
         if (DisablePreviousButton) buttons.Add(DriverJsDefaultValues.ButtonPrevious);

--- a/Blazor.DriverJs/DriverJsPopoverId.razor
+++ b/Blazor.DriverJs/DriverJsPopoverId.razor
@@ -20,6 +20,9 @@
     
     protected override async Task OnInitializedAsync()
     {
+        Model.Element = "#" + PopoverId;
+        Store.AddPopover(Step, Model);
+        
         OnDisableButtonUpdate += UpdateDisableButtons;
         OnShowButtonUpdate += UpdateShowButtons;
 

--- a/Blazor.DriverJs/DriverJsPopoverId.razor
+++ b/Blazor.DriverJs/DriverJsPopoverId.razor
@@ -1,27 +1,29 @@
-﻿using Blazor.DriverJs.Enums;
-using Blazor.DriverJs.Models;
-using Microsoft.AspNetCore.Components;
+@inherits DriverJsPopoverProps
+@using Microsoft.JSInterop
+@implements IAsyncDisposable
 
-namespace Blazor.DriverJs;
+@ChildContent(PopoverId)
 
-public partial class DriverJsPopover : IAsyncDisposable
-{
-    private ElementReference Ref
-    {
-        set
-        {
-            Model.Element = value;
-            Store.AddPopover(Step, Model);
-        }
-    }
+@code {
+
+    private string PopoverId => $"popover-{GetHashCode()}";
+
+    [Parameter] public RenderFragment<string> ChildContent { get; set; }
+
+    [Parameter, EditorRequired] public int Step { get; set; }
 
     [CascadingParameter] public DriverStore Store { get; set; }
 
-    protected override void OnInitialized()
+    [Inject] public IJSRuntime Js { get; set; }
+    
+    [Inject] public DriverJs DriverJs { get; set; }
+    
+    protected override async Task OnInitializedAsync()
     {
         OnDisableButtonUpdate += UpdateDisableButtons;
         OnShowButtonUpdate += UpdateShowButtons;
-        base.OnInitialized();
+
+        await base.OnInitializedAsync();
     }
 
     private void UpdateShowButtons(object? sender, EventArgs args)
@@ -53,4 +55,5 @@ public partial class DriverJsPopover : IAsyncDisposable
         Store.RemovePopover(Step);
         return ValueTask.CompletedTask;
     }
+
 }

--- a/Blazor.DriverJs/DriverJsPopoverProps.cs
+++ b/Blazor.DriverJs/DriverJsPopoverProps.cs
@@ -5,8 +5,11 @@ using Microsoft.AspNetCore.Components;
 
 namespace Blazor.DriverJs;
 
-public partial class DriverJsPopover
+public class DriverJsPopoverProps : ComponentBase
 {
+    protected EventHandler? OnDisableButtonUpdate;
+    protected EventHandler? OnShowButtonUpdate;
+    
     #region Props
 
     [Parameter] public RenderFragment? ChildContent { get; set; }
@@ -111,7 +114,7 @@ public partial class DriverJsPopover
         set
         {
             _disableCloseButton = value;
-            UpdateDisableButtons();
+            OnDisableButtonUpdate?.Invoke(this, EventArgs.Empty);
         }
     }
 
@@ -128,7 +131,7 @@ public partial class DriverJsPopover
         set
         {
             _disableNextButton = value;
-            UpdateDisableButtons();
+            OnDisableButtonUpdate?.Invoke(this, EventArgs.Empty);
         }
     }
 
@@ -145,7 +148,7 @@ public partial class DriverJsPopover
         set
         {
             _disablePreviousButton = value;
-            UpdateDisableButtons();
+            OnDisableButtonUpdate?.Invoke(this, EventArgs.Empty);
         }
     }
 
@@ -165,7 +168,7 @@ public partial class DriverJsPopover
         set
         {
             _showCloseButtons = value;
-            UpdateShowButtons();
+            OnShowButtonUpdate?.Invoke(this, EventArgs.Empty);
         }
     }
 
@@ -181,7 +184,7 @@ public partial class DriverJsPopover
         set
         {
             _showNextButton = value;
-            UpdateShowButtons();
+            OnShowButtonUpdate?.Invoke(this, EventArgs.Empty);
         }
     }
 
@@ -197,7 +200,7 @@ public partial class DriverJsPopover
         set
         {
             _showPreviousButton = value;
-            UpdateShowButtons();
+            OnShowButtonUpdate?.Invoke(this, EventArgs.Empty);
         }
     }
 

--- a/Blazor.DriverJs/DriverJsPopoverProps.cs
+++ b/Blazor.DriverJs/DriverJsPopoverProps.cs
@@ -5,19 +5,15 @@ using Microsoft.AspNetCore.Components;
 
 namespace Blazor.DriverJs;
 
-public class DriverJsPopoverProps : ComponentBase
+public abstract class DriverJsPopoverProps : ComponentBase
 {
     protected EventHandler? OnDisableButtonUpdate;
     protected EventHandler? OnShowButtonUpdate;
     
     #region Props
-
-    [Parameter] public RenderFragment? ChildContent { get; set; }
-
+    
     [Parameter] public PopoverModel Model { get; set; } = new();
-
-    [Parameter, EditorRequired] public int Step { get; set; }
-
+    
     [Parameter]
     public string? Class
     {

--- a/Blazor.DriverJs/Models/HighlightModel.cs
+++ b/Blazor.DriverJs/Models/HighlightModel.cs
@@ -4,8 +4,8 @@ namespace Blazor.DriverJs.Models;
 
 public class HighlightModel
 {
-    public ElementReference Element { get; set; }
-    
+    public object Element { get; set; }
+
     /// <summary>
     /// Title show in the popover.
     /// You can use HTML in these. Also, you can omit one of these to show only the other.
@@ -22,7 +22,7 @@ public class HighlightModel
     /// values: top, right, bottom, left
     /// </summary>
     public string Side { get; set; } = DriverJsDefaultValues.DefaultSide;
-    
+
     /// <summary>
     /// values: start, center, end
     /// </summary>
@@ -31,5 +31,10 @@ public class HighlightModel
     public HighlightModel(ElementReference reference)
     {
         Element = reference;
+    }
+
+    public HighlightModel(string elementId)
+    {
+        Element = "#" + elementId;
     }
 }

--- a/Blazor.DriverJs/Models/PopoverModel.cs
+++ b/Blazor.DriverJs/Models/PopoverModel.cs
@@ -1,10 +1,8 @@
-﻿using Microsoft.AspNetCore.Components;
-
-namespace Blazor.DriverJs.Models;
+﻿namespace Blazor.DriverJs.Models;
 
 public class PopoverModel
 {
-    public ElementReference Element { get; set; }
+    public object Element { get; set; }
 
     /// <summary>
     /// Title show in the popover.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ The `DriverStore` component is used here to store references to Popovers and to 
 
 `DriverJsPopover` is a component that represents a popover in which we specify the step in which it will be called by passing parameters such as title, description, ...
 
+`DriverJsPopoverId` analogous to DriverJsPopover, but in this place there is a link to the element id.
+
 To be able to work with `DriverStore` we must declare a reference variable to interact with the API.
 
 ```html
@@ -47,6 +49,11 @@ To be able to work with `DriverStore` we must declare a reference variable to in
         <DriverJsPopover Step="3" Title="And that's a cool smiley face">
             <img src="https://i.pinimg.com/736x/40/bb/da/40bbdac7db3945f95eb9cfe572d36ecd.jpg" alt="">
         </DriverJsPopover>
+
+        <DriverJsPopoverId Step="4" Title="Hello World">
+            <img src="https://i.pinimg.com/736x/40/bb/da/40bbdac7db3945f95eb9cfe572d36ecd.jpg" alt=""
+                 id="@context">
+        </DriverJsPopoverId>
     </DriverStore>
 </div>
 
@@ -66,6 +73,10 @@ To highlight a single object, we can use the `DriverJs` service and call the Hig
     Click me
 </button>
 
+<button @onclick="ClickHandler2" id="super-button">
+    Click me
+</button>
+
 @code {
 
   private ElementReference _ref;
@@ -73,6 +84,14 @@ To highlight a single object, we can use the `DriverJs` service and call the Hig
   private async Task ClickHandler()
   {
       await DriverJs.Highlight(new HighlightModel(_ref)
+      {
+          Title = "Hello World",
+      });
+  }
+
+  private async Task ClickHandler2()
+  {
+      await DriverJs.Highlight(new HighlightModel("super-button")
       {
           Title = "Hello World",
       });


### PR DESCRIPTION
I updated the `DriverJsPopover` component, where I rewrote the data initialization a bit.

Created a new `DriverJsPopoverId` component in which it is not necessary to bind an element via `ElementReference`.

Updated `PopoverModel`, `HighlightModel` models in which I removed the close binding of models to `ElementReference` thus shifting the responsibility for data validity to the calling program.