### PR TITLE
Create IDriverJs interface

### DIFF
--- a/Blazor.DriverJs.Web/Pages/Index.razor
+++ b/Blazor.DriverJs.Web/Pages/Index.razor
@@ -42,7 +42,7 @@
 
     private ElementReference _ref;
 
-    [Inject] public DriverJs DriverJs { get; set; }
+    [Inject] public IDriverJs DriverJs { get; set; }
 
     private async Task ClickHandler()
     {

--- a/Blazor.DriverJs.Web/Program.cs
+++ b/Blazor.DriverJs.Web/Program.cs
@@ -6,7 +6,7 @@ var builder = WebApplication.CreateBuilder(args);
 
 builder.Services.AddRazorPages();
 builder.Services.AddServerSideBlazor();
-builder.Services.AddScoped<DriverJs>();
+builder.Services.RegisterDriverJs();
 
 var app = builder.Build();
 

--- a/Blazor.DriverJs/DriverJs.cs
+++ b/Blazor.DriverJs/DriverJs.cs
@@ -3,7 +3,7 @@ using Microsoft.JSInterop;
 
 namespace Blazor.DriverJs;
 
-public class DriverJs : IDisposable
+public class DriverJs : IDriverJs
 {
     private readonly Lazy<Task<IJSObjectReference>> _jsModule;
 

--- a/Blazor.DriverJs/DriverJsPopoverId.razor
+++ b/Blazor.DriverJs/DriverJsPopoverId.razor
@@ -16,7 +16,7 @@
 
     [Inject] public IJSRuntime Js { get; set; }
     
-    [Inject] public DriverJs DriverJs { get; set; }
+    [Inject] public IDriverJs DriverJs { get; set; }
     
     protected override async Task OnInitializedAsync()
     {

--- a/Blazor.DriverJs/DriverStore.razor.cs
+++ b/Blazor.DriverJs/DriverStore.razor.cs
@@ -40,7 +40,7 @@ public partial class DriverStore : IDisposable
 
     #region Services
 
-    [Inject] public DriverJs DriverJs { get; set; }
+    [Inject] public IDriverJs DriverJs { get; set; }
 
     #endregion
 

--- a/Blazor.DriverJs/IDriverJs.cs
+++ b/Blazor.DriverJs/IDriverJs.cs
@@ -1,0 +1,9 @@
+﻿using Blazor.DriverJs.Models;
+using Microsoft.JSInterop;
+
+namespace Blazor.DriverJs;
+public interface IDriverJs : IDisposable
+{
+    Task StartDrive(DriverModel model, DotNetObjectReference<DriverStore> dotObj);
+    Task Highlight(HighlightModel model);
+}

--- a/Blazor.DriverJs/ServiceCollectionExtensions.cs
+++ b/Blazor.DriverJs/ServiceCollectionExtensions.cs
@@ -1,0 +1,10 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+
+namespace Blazor.DriverJs;
+public static class ServiceCollectionExtensions
+{
+    public static void RegisterDriverJs(this IServiceCollection serviceCollection)
+    {
+        serviceCollection.AddScoped<IDriverJs, DriverJs>();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Add to body
 ```
 Register service to DI
 ```c
-builder.Services.AddScoped<DriverJs>();
+builder.Services.RegisterDriverJs();
 ```
 # Examples
 


### PR DESCRIPTION
This is a breaking change. The reason for this is that some environments, driver js doesn't work, and I need to disable it. Or maybe other's need to mock it for test. A common thing to do would also be to make DriverJs internal, but I didn't do that in this PR.

If you'd like an example, I have a fork that I'm using in postman2csharp that I have to mock DriverJs in. See [ServerDriverJs](https://github.com/biegehydra/Postman2CSharp/blob/master/src/Postman2CSharp.UI/Services/ServerDriverJs.cs). The reason I have to mock DriverJs there is because it just bugs out on server mode. That is a whole problem in itself that you could investigate if you want but for me it doesn't matter because I only use server mode for testing and publish with wasm - where it works. 

If you want to debug that, clone the project, go to `ServiceCollectionExtensions`, change it to use the actual DriverJs, run the project in SERVER MODE, generate an apiclient from a postman collection, and once it auto-navigates you to the collection, you will see the bug.

## Wasm

![Wasm](https://github.com/ilsadq/Blazor.DriverJs/assets/84036995/797b6b1c-2b79-434f-bc22-0ddb01f9af6a)

## Server

![BlazorServer](https://github.com/ilsadq/Blazor.DriverJs/assets/84036995/8ec942da-696a-4113-bac6-5764aaebad35)
